### PR TITLE
Fix max uint32 value

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6,7 +6,7 @@ module.exports = (function (global) {
   if (!good) return Math.random
 
   var arr = new Uint32Array(1)
-  var max = Math.pow(2, 32)
+  var max = 0xFFFFFFFF
   function random () {
     crypto.getRandomValues(arr)
     return arr[0] / max

--- a/node.js
+++ b/node.js
@@ -1,5 +1,5 @@
 var crypto = require('crypto')
-var max = Math.pow(2, 32)
+var max = 0xFFFFFFFF
 
 module.exports = random
 module.exports.cryptographic = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "math-random",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "a drop-in replacement for Math.random that uses cryptographically secure random number generation, where available",
   "main": "node.js",
   "browser": "browser.js",
@@ -23,6 +23,10 @@
     "crypto.getRandomValues"
   ],
   "author": "Michael Rhodes",
+  "contributors": [
+    "Michael Rhodes",
+    "Robert Manolea <manolea.robert@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/michaelrhodes/math-random/issues"


### PR DESCRIPTION
The maximum value of uint32 is `Math.pow(2, 32) - 1` or `0xFFFFFFFF` or `4294967295` not the current value.

Did the version bump while at it too 😃 